### PR TITLE
ToggleSwitch OnMouseClick Bug

### DIFF
--- a/Bootstrap.vb
+++ b/Bootstrap.vb
@@ -618,7 +618,7 @@ Namespace Bootstrap
                 MyBase.OnMouseClick(e)
 
                 _checked = Not _checked
-                Me.Invalidate(True)
+                OnCheckedChanged()
             End Sub
 
             Protected Overrides Sub OnMouseMove(ByVal e As MouseEventArgs)


### PR DESCRIPTION
The OnMouseClick event was calling the Invalidate method on the ToggleSwitch. This inadvertently caused the CheckedChanged event to not fire when the user would toggle the ToggleSwitch.

The fix was to replace Me.Invalidate(True) with OnCheckChanged() in the OnMouseClick event.